### PR TITLE
Fix error when clicking the "Google Geocoder Api needs a KEY first, see Configure" label

### DIFF
--- a/locatorfilters/googlegeocoder.py
+++ b/locatorfilters/googlegeocoder.py
@@ -93,6 +93,7 @@ class GoogleGeocodeFilter(GeocoderFilter):
 
         doc = result.userData
         bounds = None
+        viewport = None
         if doc is not None and 'geometry' in doc:
             g = doc['geometry']
             if 'bounds' in g:


### PR DESCRIPTION
If you don't have Google API key, you get this label instead of results:

![zrzut_20180406_132145](https://user-images.githubusercontent.com/1000043/38418625-8103c996-399d-11e8-8ea9-41f1f2b872a1.png)

This PR fixes an exception raised when you (more or less) accidentally click that label.